### PR TITLE
Updated JavaDoc for spelling/alignment - Fixes #31

### DIFF
--- a/src/main/java/org/selophane/elements/widget/Table.java
+++ b/src/main/java/org/selophane/elements/widget/Table.java
@@ -10,7 +10,7 @@ import org.selophane.elements.base.ImplementedBy;
 @ImplementedBy(TableImpl.class)
 public interface Table extends Element {
 
-	/**
+    /**
      * Gets the number of rows in the table
      * @return int equal to the number of rows in the table
      */
@@ -18,7 +18,7 @@ public interface Table extends Element {
 
     /**
      * Gets the number of columns in the table
-     * @return int equal to the number of rows in the table
+     * @return int equal to the number of columns in the table
      */
     int getColumnCount();
 


### PR DESCRIPTION
Happened to be using this myself and saw the misspelling in the javadoc and figured I'd correct it with a quick change.

- Corrected alignment of JavaDoc on getRowCount() method
- Corrected return field for JavaDoc in getColumnCount() method