### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <selenium.version>3.141.59</selenium.version>
     <htmlDriver.version>2.52.0</htmlDriver.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencies>
@@ -93,6 +94,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.12.4</version>
+        <configuration>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
